### PR TITLE
Add Login to ECR Command

### DIFF
--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -1,0 +1,28 @@
+description: >
+    Generate credentials to log in to ECR.
+
+parameters:
+    generator-url:
+      description: 'Generate Docker Credentials Endpoint'
+        type: string
+
+    environment:
+        description: 'ID of the environment'
+        type: string
+
+    region:
+        description: 'AWS region'
+        type: string
+
+steps:
+    - run:
+        name: 'Generates Credentials and logs in to ECR'
+        command: |
+          read endpoint token < <(echo $(curl --request POST \
+          "<< parameters.generator-url >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
+          --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))
+
+          # the token is base64 encoded with username:password
+          echo "${token}" | base64 -d | cut -d: -f2 | docker login \
+            --username AWS |
+            --password-stdin "${endpoint}"

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -2,7 +2,7 @@ description: >
     Generate an authentication token and logs into ECR.
 
 parameters:
-    generator-url:
+    generator-endpoint:
       description: 'Generate Docker Credentials Endpoint'
         type: string
 

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -44,7 +44,7 @@ steps:
       name: 'Generates Docker Credentials'
       command: |
           if [[ "${<< parameters.api-token-var >>}" != "HAL_API_TOKEN" ]] ; then
-              echo "export HAL_API_TOKEN=${<< parameters.api-token-var >>}" >> $BASH_ENV
+              export HAL_API_TOKEN="${<< parameters.api-token-var >>}"
           fi
 
           read endpoint token < <(echo $(curl --request POST \

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -22,7 +22,6 @@ steps:
           "<< parameters.generator-endpoint >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
           --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))
 
-          # the token is base64 encoded with username:password
           echo "${token}" docker login \
             --username AWS |
             --password-stdin "${endpoint}"

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -28,6 +28,6 @@ steps:
           "<< parameters.generator-url >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
           --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))
 
-          echo "${token}" docker login \
+          echo "${token}" | docker login \
             --username AWS \
             --password-stdin "${endpoint}"

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -15,13 +15,19 @@ parameters:
         type: string
 
 steps:
-    - run:
-        name: 'Generate Credentials and Login to ECR'
-        command: |
+  - run:
+      name: Install jq
+      command: |
+          sudo apt-get update
+          sudo apt-get install jq -y
+
+  - run:
+      name: 'Generates Docker Credentials'
+      command: |
           read endpoint token < <(echo $(curl --request POST \
-          "<< parameters.generator-endpoint >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
+          "<< parameters.generator-url >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
           --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))
 
           echo "${token}" docker login \
-            --username AWS |
+            --username AWS \
             --password-stdin "${endpoint}"

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -3,8 +3,13 @@ description: >
 
 parameters:
     generator-endpoint:
-      description: 'Generate Docker Credentials Endpoint'
+        description: 'Generate Docker Credentials Endpoint'
         type: string
+
+    api-token-var:
+        description: 'Environment variable that is read for the Hal API token.'
+        default: HAL_API_TOKEN
+        type: env_var_name
 
     environment:
         description: 'ID of the environment'
@@ -18,12 +23,30 @@ steps:
   - run:
       name: Install jq
       command: |
-          sudo apt-get update
-          sudo apt-get install jq -y
+          if command -v jq >> /dev/null 2>&1; then
+              echo "jq is already installed..."
+          else
+              if command -v apt-get >> /dev/null 2>&1; then
+                  sudo_me="sudo "
+                  if [ "$(whoami)" == "root" ] ; then
+                    sudo_me=""
+                  fi
+
+                  ${sudo_me} apt-get update
+                  ${sudo_me} apt-get install jq -y
+              else
+                  echo "jq is required. Please install it before running this step."
+                  exit 1
+              fi
+          fi
 
   - run:
       name: 'Generates Docker Credentials'
       command: |
+          if [[ "${<< parameters.api-token-var >>}" != "HAL_API_TOKEN" ]] ; then
+              echo "export HAL_API_TOKEN=${<< parameters.api-token-var >>}" >> $BASH_ENV
+          fi
+
           read endpoint token < <(echo $(curl --request POST \
           "<< parameters.generator-url >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
           --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -23,6 +23,6 @@ steps:
           --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))
 
           # the token is base64 encoded with username:password
-          echo "${token}" | base64 -d | cut -d: -f2 | docker login \
+          echo "${token}" docker login \
             --username AWS |
             --password-stdin "${endpoint}"

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -1,5 +1,5 @@
 description: >
-    Generate credentials to log in to ECR.
+    Generate an authentication token and logs into ECR.
 
 parameters:
     generator-url:
@@ -16,7 +16,7 @@ parameters:
 
 steps:
     - run:
-        name: 'Generates Credentials and logs in to ECR'
+        name: 'Generate Credentials and Login to ECR'
         command: |
           read endpoint token < <(echo $(curl --request POST \
           "<< parameters.generator-url >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \

--- a/hal/commands/login-to-ecr.yml
+++ b/hal/commands/login-to-ecr.yml
@@ -1,5 +1,5 @@
 description: >
-    Generate an authentication token and logs into ECR.
+    Generate an authentication token and log into ECR.
 
 parameters:
     generator-endpoint:
@@ -19,7 +19,7 @@ steps:
         name: 'Generate Credentials and Login to ECR'
         command: |
           read endpoint token < <(echo $(curl --request POST \
-          "<< parameters.generator-url >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
+          "<< parameters.generator-endpoint >>?environment=<< parameters.environment >>&region=<< parameters.region >>" \
           --header "Authorization: token ${HAL_API_TOKEN}" | jq -r '.proxy_endpoint, .authorization_token' ))
 
           # the token is base64 encoded with username:password


### PR DESCRIPTION
This adds a new Hal Orb command that allows users to generate a token and then we log into ECR. 

Users need to provide the HAL generate AWS creds endpoint with their org id, the environment id, and the AWS region. 

One thing to note is that the token is base64 encoded. `echo "${token}" | base64 -d | cut -d: -f2` gives us just the token that we need. 